### PR TITLE
Replaced deprecated events method

### DIFF
--- a/src/Services/ImpersonateManager.php
+++ b/src/Services/ImpersonateManager.php
@@ -126,7 +126,7 @@ class ImpersonateManager
             $this->clear();
             $token = $this->deferLogin($impersonator);
 
-            $this->app['events']->fire(new LeaveImpersonation($impersonator, $impersonated));
+            $this->app['events']->dispatch(new LeaveImpersonation($impersonator, $impersonated));
 
             return $token;
         } else {


### PR DESCRIPTION
The manager's leave method was still using the deprecated fire() events method.